### PR TITLE
Fixed code scanning alert - Arbitrary file access during archive extraction ("Zip Slip") #7

### DIFF
--- a/src/jvmMain/kotlin/utils/FileUtils.kt
+++ b/src/jvmMain/kotlin/utils/FileUtils.kt
@@ -5,6 +5,7 @@ import java.io.File
 import java.io.IOException
 import java.io.InputStream
 import java.io.FileOutputStream
+import java.nio.file.Paths
 import java.util.zip.ZipFile
 
 object FileUtils {
@@ -44,7 +45,8 @@ object FileUtils {
                 if (entry.name == skipFile) return@forEach
 
                 zip.getInputStream(entry).use { input ->
-                    val filePath = destDirectory + File.separator + entry.name
+                    val safeEntryName = Paths.get(entry.name).normalize().toString()
+                    val filePath = destDirectory + File.separator + safeEntryName
 
                     if (!entry.isDirectory) {
                         // if the entry is a file, extracts it


### PR DESCRIPTION
Extracting files from a malicious zip file, or similar type of archive, is at risk of directory traversal attacks if filenames from the archive are not properly validated.

Zip archives contain archive entries representing each file in the archive. These entries include a file path for the entry, but these file paths are not restricted and may contain unexpected special elements such as the directory traversal element (..). If these file paths are used to create a filesystem path, then a file operation may happen in an unexpected location. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files.

For example, if a zip file contains a file entry ..\sneaky-file, and the zip file is extracted to the directory c:\output, then naively combining the paths would result in an output file path of c:\output\..\sneaky-file, which would cause the file to be written to c:\sneaky-file.